### PR TITLE
Prevent the language from being reset on clicking Go

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -53,7 +53,7 @@ class Search extends React.Component {
             type="button"
             id="search-button"
             value="GO!"
-            onClick={() => search({ query: this.state.value })}
+            onClick={() => search({ query: this.state.value , language})}
           />
           <LanguagesPicker
             updateLanguage={language =>


### PR DESCRIPTION
Hello, clicking the Go button fails to search with both the selected language and the query ( pressing the enter key after typing in the query behaves as expected ). This pull request fixes that. 